### PR TITLE
[LP#2033082] Use `yaml.safe_load` over `yaml.load`

### DIFF
--- a/lib/charms/layer/gcp.py
+++ b/lib/charms/layer/gcp.py
@@ -51,7 +51,7 @@ def get_credentials():
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        creds = yaml.load(result.stdout.decode("utf8"))
+        creds = yaml.safe_load(result.stdout.decode("utf8"))
         creds_data = creds["credential"]["attributes"]["file"]
         update_credentials_file(creds_data)
         return True

--- a/tests/integration/test_gcp_integrator.py
+++ b/tests/integration/test_gcp_integrator.py
@@ -24,7 +24,7 @@ async def test_build_and_deploy(ops_test, k8s_core_bundle, series):
     model = ops_test.model_full_name
     cmd = (
         f"juju deploy -m {model} {bundle} "
-        "--trust"
+        "--trust " +
         " ".join(f"--overlay={f}" for f in overlays)
     )
     rc, stdout, stderr = await ops_test.run(*shlex.split(cmd))

--- a/tests/integration/test_gcp_integrator.py
+++ b/tests/integration/test_gcp_integrator.py
@@ -22,10 +22,8 @@ async def test_build_and_deploy(ops_test, k8s_core_bundle, series):
     bundle, *overlays = await ops_test.async_render_bundles(*overlays, **context)
     log.info("Deploy Charm...")
     model = ops_test.model_full_name
-    cmd = (
-        f"juju deploy -m {model} {bundle} "
-        "--trust " +
-        " ".join(f"--overlay={f}" for f in overlays)
+    cmd = f"juju deploy -m {model} {bundle} --trust " + " ".join(
+        f"--overlay={f}" for f in overlays
     )
     rc, stdout, stderr = await ops_test.run(*shlex.split(cmd))
     assert rc == 0, f"Bundle deploy failed: {(stderr or stdout).strip()}"


### PR DESCRIPTION
PYyaml 6.0 finally drops `yaml.load` without a `Loader`.  Switching to `safe_load` instead